### PR TITLE
Implemented TinyBadge feature

### DIFF
--- a/src/Xam.Shell.Badge.Android/Renderers/CustomShellBottomAppearance.cs
+++ b/src/Xam.Shell.Badge.Android/Renderers/CustomShellBottomAppearance.cs
@@ -77,6 +77,11 @@ namespace Xam.Shell.Badge.Droid.Renderers
             {
                 CreatePageBadge(value, false, 0, _bottomNavigationMenuView);
             });
+
+            MessagingCenter.Subscribe<BottomBarHelper, int[]>(this, "SetTinyBadge", (sender, values) =>
+            {
+                CreatePageTinyBadge(values[0], true, values[1] , values[2] , values[3], _bottomNavigationMenuView);
+            });
         }
 
         #endregion
@@ -107,6 +112,33 @@ namespace Xam.Shell.Badge.Droid.Renderers
                     mtxtnotificationsbadge.SetBackgroundResource(Resource.Drawable.custom_circle_shape);
                 else
                     mtxtnotificationsbadge.SetBackgroundResource(Resource.Drawable.custom_rectangle_shape);
+            }
+            else
+            {
+                var badgeLayout = itemView.FindViewById<FrameLayout>(Resource.Id.badge);
+                if (badgeLayout != null)
+                    itemView.RemoveView(badgeLayout);
+            }
+        }
+
+        /* TinyBadge is simply a styled bullet with on transparent background
+         */
+        private void CreatePageTinyBadge(int index, bool ShowBadge,  int R , int G , int B, BottomNavigationMenuView _bottomNavigationMenuView)
+        {
+            var itemView = (BottomNavigationItemView)_bottomNavigationMenuView.GetChildAt(index);
+            if (ShowBadge)
+            {
+                var mtxtnotificationsbadge = itemView.FindViewById<TextView>(Resource.Id.txtbadge);
+                if (mtxtnotificationsbadge == null)
+                {
+                    var vBadge = LayoutInflater.From(CrossCurrentActivity.Current.Activity).Inflate(Resource.Layout.notification_badge, _bottomNavigationMenuView, false);
+                    itemView.AddView(vBadge);
+                    mtxtnotificationsbadge = itemView.FindViewById<TextView>(Resource.Id.txtbadge);
+                }
+                mtxtnotificationsbadge.Text = "●";
+                mtxtnotificationsbadge.TextSize = 24;
+                mtxtnotificationsbadge.SetBackgroundColor(Android.Graphics.Color.Transparent);
+                mtxtnotificationsbadge.SetTextColor(new Android.Graphics.Color(R , G , B));
             }
             else
             {

--- a/src/Xam.Shell.Badge.iOS/Renderers/CustomShellBottomAppearance.cs
+++ b/src/Xam.Shell.Badge.iOS/Renderers/CustomShellBottomAppearance.cs
@@ -52,6 +52,16 @@ namespace Xam.Shell.Badge.iOS.Renderers
                 if (controller?.TabBar?.Items != null && controller.TabBar.Items.Any())
                     controller.TabBar.Items[value].BadgeValue = null;
             });
+
+            MessagingCenter.Subscribe<BottomBarHelper, int[]>(this, "SetTinyBadge", (sender, values) =>
+            {
+                if (controller?.TabBar?.Items != null && controller.TabBar.Items.Any())
+                {
+                    controller.TabBar.Items[values[0]].BadgeColor = UIColor.Clear;
+                    controller.TabBar.Items[values[0]].BadgeValue = "●";
+                    controller.TabBar.Items[values[0]].SetBadgeTextAttributes(new UIStringAttributes() { ForegroundColor = UIColor.FromRGB(values[1], values[2], values[3]) }, UIControlState.Normal);
+                }
+            });
         }
 
         #endregion

--- a/src/Xam.Shell.Badge/BottomBarHelper.cs
+++ b/src/Xam.Shell.Badge/BottomBarHelper.cs
@@ -28,6 +28,15 @@ namespace Xam.Shell.Badge
             MessagingCenter.Send<BottomBarHelper, int>(this, "RemoveBadge", position);
         }
 
+        /// <summary>
+        /// Set a tiny badge for a bottombar item. A tiny badge is a small filled circle with no number. 
+        /// </summary>
+        /// <param name="position">The tab position<see cref="int"/>.</param>
+        /// <param name="color">The color value of the tiny badge<see cref="Color"/>.</param>
+        public void SetTinyBadge(int position, Color color)
+        {
+            MessagingCenter.Send<BottomBarHelper, int[]>(this, "SetTinyBadge", new int[] { position, (int)(color.R * 255), (int)(color.G * 255), (int)(color.B * 255) });
+        }
         #endregion
     }
 }


### PR DESCRIPTION
 TinyBadge is small filled cycle without a counter, smaller than a regular badge. e.g. the green dot in the screenshot below.

`SetTinyBadge(int position, Color color)`  takes a tab position and color value. 
To remove a TinyBadge, just use RemoveBadge(int position) which works on both regular and tiny badges. 

![image](https://user-images.githubusercontent.com/33980667/96633525-e57daf80-1321-11eb-9fc8-d98f2c3a78b5.png)
