### PR TITLE
Nuget tiny re-struction & small change on the responsibility of BadgeShellItemRenderer

### DIFF
--- a/sample/Xam.Shell.Badge.Sample.sln
+++ b/sample/Xam.Shell.Badge.Sample.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.32106.194
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32112.339
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xam.Shell.Badge.Sample.Android", "Xam.Shell.Badge.Sample\Xam.Shell.Badge.Sample.Android\Xam.Shell.Badge.Sample.Android.csproj", "{97BC6726-6D88-4958-84BD-209E5375B9C8}"
 EndProject

--- a/sample/Xam.Shell.Badge.Sample/Xam.Shell.Badge.Sample.Android/MainActivity.cs
+++ b/sample/Xam.Shell.Badge.Sample/Xam.Shell.Badge.Sample.Android/MainActivity.cs
@@ -1,7 +1,6 @@
 ﻿using Android.App;
 using Android.Content.PM;
 using Android.OS;
-using Plugin.CurrentActivity;
 using Xam.Shell.Badge.Droid;
 
 namespace Xam.Shell.Badge.Sample.Droid
@@ -17,7 +16,6 @@ namespace Xam.Shell.Badge.Sample.Droid
             base.OnCreate(savedInstanceState);
 
             Xamarin.Forms.Forms.Init(this, savedInstanceState);
-            CrossCurrentActivity.Current.Init(this, savedInstanceState);
             BottomBar.Init();
             LoadApplication(new App());
         }

--- a/sample/Xam.Shell.Badge.Sample/Xam.Shell.Badge.Sample.Android/Xam.Shell.Badge.Sample.Android.csproj
+++ b/sample/Xam.Shell.Badge.Sample/Xam.Shell.Badge.Sample.Android/Xam.Shell.Badge.Sample.Android.csproj
@@ -47,12 +47,6 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AsyncAwaitBestPractices">
-      <Version>6.0.4</Version>
-    </PackageReference>
-    <PackageReference Include="Plugin.CurrentActivity">
-      <Version>2.1.0.4</Version>
-    </PackageReference>
     <PackageReference Include="Xam.Shell.Badge">
       <Version>1.0.15</Version>
     </PackageReference>

--- a/sample/Xam.Shell.Badge.Sample/Xam.Shell.Badge.Sample.iOS/Xam.Shell.Badge.Sample.iOS.csproj
+++ b/sample/Xam.Shell.Badge.Sample/Xam.Shell.Badge.Sample.iOS/Xam.Shell.Badge.Sample.iOS.csproj
@@ -117,9 +117,6 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AsyncAwaitBestPractices">
-      <Version>6.0.4</Version>
-    </PackageReference>
     <PackageReference Include="Xam.Shell.Badge">
       <Version>1.0.15</Version>
     </PackageReference>

--- a/src/Xam.Shell.Badge.Android/Renderers/BadgeShellItemRenderer.cs
+++ b/src/Xam.Shell.Badge.Android/Renderers/BadgeShellItemRenderer.cs
@@ -48,14 +48,20 @@ namespace Xam.Shell.Badge.Droid.Renderers
             var outerlayout = base.OnCreateView(inflater, container, savedInstanceState);
 
             _bottomNavigationView = outerlayout.FindViewById<BottomNavigationView>(Resource.Id.bottomtab_tabbar);
-            _bottomNavigationView.Post(() =>
-            {
-                Device
-                    .InvokeOnMainThreadAsync(InitBadges)
-                    .SafeFireAndForget();
-            });
 
             return outerlayout;
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
+        public override void OnResume()
+        {
+            base.OnResume();
+
+            Device
+                .InvokeOnMainThreadAsync(InitBadges)
+                .SafeFireAndForget();
         }
 
         /// <summary>
@@ -92,8 +98,11 @@ namespace Xam.Shell.Badge.Droid.Renderers
 
         private void ApplyBadge(int itemId, string badgeText, Color badgeBg, Color textColor)
         {
-            using var bottomNavigationMenuView = (BottomNavigationMenuView)_bottomNavigationView.GetChildAt(0);
+            if (default == _bottomNavigationView)
+                return;
 
+            using var bottomNavigationMenuView = (BottomNavigationMenuView)_bottomNavigationView.GetChildAt(0);
+            
             var itemView = bottomNavigationMenuView.FindViewById<BottomNavigationItemView>(itemId);
             if (default == itemView)
                 return;

--- a/src/Xam.Shell.Badge.Android/Xam.Shell.Badge.Android.csproj
+++ b/src/Xam.Shell.Badge.Android/Xam.Shell.Badge.Android.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -58,9 +58,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AsyncAwaitBestPractices">
-      <Version>6.0.4</Version>
-    </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2291</Version>
     </PackageReference>
@@ -69,12 +66,6 @@
     <AndroidResource Include="Resources\values\colors.xml">
       <Generator>MSBuild:UpdateGeneratedFiles</Generator>
     </AndroidResource>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Xam.Shell.Badge\Xam.Shell.Badge.csproj">
-      <Project>{73e6d6b8-23a2-4200-ac4b-1819dc261b12}</Project>
-      <Name>Xam.Shell.Badge</Name>
-    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/Xam.Shell.Badge.iOS/Xam.Shell.Badge.iOS.csproj
+++ b/src/Xam.Shell.Badge.iOS/Xam.Shell.Badge.iOS.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -47,21 +47,12 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Xam.Shell.Badge\Xam.Shell.Badge.csproj">
-      <Project>{73e6d6b8-23a2-4200-ac4b-1819dc261b12}</Project>
-      <Name>Xam.Shell.Badge</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <Compile Include="BottomBar.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Renderers\BadgeShellItemRenderer.cs" />
     <Compile Include="Renderers\BadgeShellRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="AsyncAwaitBestPractices">
-      <Version>6.0.4</Version>
-    </PackageReference>
     <PackageReference Include="Xamarin.Forms">
       <Version>5.0.0.2291</Version>
     </PackageReference>


### PR DESCRIPTION
## PR overview
This PR includes:
- Some nuget packages were removed for the convenience;
- Change on the Android BadgeShellItemRenderer: `InitBadges` method will be called from `OnResume` method.

## What's changed
- Nuget dependencies on both source and sample projects;
- Android's shell item renderer.

## Actions required
- Nuget package needs to be updated;
- Sample project needs to be updated.