### PR TITLE
Important change on how iOS handles zero value color & fix one of the recent comments on the Issue #25

### DIFF
--- a/sample/Xam.Shell.Badge.Sample/Xam.Shell.Badge.Sample.iOS/AppDelegate.cs
+++ b/sample/Xam.Shell.Badge.Sample/Xam.Shell.Badge.Sample.iOS/AppDelegate.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-using Foundation;
+﻿using Foundation;
 using UIKit;
 using Xam.Shell.Badge.iOS;
 
@@ -11,8 +7,8 @@ namespace Xam.Shell.Badge.Sample.iOS
     // The UIApplicationDelegate for the application. This class is responsible for launching the
     // User Interface of the application, as well as listening (and optionally responding) to
     // application events from iOS.
-    [Register("AppDelegate")]
-    public partial class AppDelegate : global::Xamarin.Forms.Platform.iOS.FormsApplicationDelegate
+    [Register(nameof(AppDelegate))]
+    public partial class AppDelegate : Xamarin.Forms.Platform.iOS.FormsApplicationDelegate
     {
         //
         // This method is invoked when the application has loaded and is ready to run. In this
@@ -23,7 +19,7 @@ namespace Xam.Shell.Badge.Sample.iOS
         //
         public override bool FinishedLaunching(UIApplication uiApplication, NSDictionary launchOptions)
         {
-            global::Xamarin.Forms.Forms.Init();
+            Xamarin.Forms.Forms.Init();
             BottomBar.Init();
             LoadApplication(new App());
 

--- a/sample/Xam.Shell.Badge.Sample/Xam.Shell.Badge.Sample.iOS/Main.cs
+++ b/sample/Xam.Shell.Badge.Sample/Xam.Shell.Badge.Sample.iOS/Main.cs
@@ -1,30 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-using Foundation;
-using UIKit;
+﻿using UIKit;
 
 namespace Xam.Shell.Badge.Sample.iOS
 {
-   public class Application
-   {
-      #region Constructor & Destructor
+    public class Application
+    {
+        /// <summary>
+        /// Default constructor
+        /// </summary>
+        protected Application() { }
 
-      /// <summary>
-      /// Default constructor
-      /// </summary>
-      protected Application()
-      { }
-
-      #endregion
-
-      // This is the main entry point of the application.
-      static void Main(string[] args)
-      {
-         // if you want to use a different Application Delegate class from "AppDelegate"
-         // you can specify it here.
-         UIApplication.Main(args, null, "AppDelegate");
-      }
-   }
+        // This is the main entry point of the application.
+        static void Main(string[] args)
+        {
+            // if you want to use a different Application Delegate class from "AppDelegate"
+            // you can specify it here.
+            UIApplication.Main(args, null, typeof(AppDelegate));
+        }
+    }
 }

--- a/src/Xam.Shell.Badge.iOS/Renderers/BadgeShellItemRenderer.cs
+++ b/src/Xam.Shell.Badge.iOS/Renderers/BadgeShellItemRenderer.cs
@@ -77,34 +77,37 @@ namespace Xam.Shell.Badge.iOS.Renderers
         {
             if (TabBar.Items.Any())
             {
-                if (default == TabBar.Items.ElementAtOrDefault(index))
-                    return;
-
-                int.TryParse(text, out var badgeValue);
-
-                if (!string.IsNullOrEmpty(text))
+                if (TabBar.Items.ElementAtOrDefault(index) is UITabBarItem currentTabBarItem)
                 {
+                    int.TryParse(text, out var badgeValue);
+
+                    if (string.IsNullOrEmpty(text))
+                    {
+                        currentTabBarItem.BadgeValue = default;
+                        currentTabBarItem.BadgeColor = UIColor.Clear;
+                        return;
+                    }
+
                     if (badgeValue == 0)
                     {
-                        TabBar.Items[index].BadgeValue = "●";
-                        TabBar.Items[index].BadgeColor = UIColor.Clear;
+                        currentTabBarItem.BadgeValue = "●";
+                        currentTabBarItem.BadgeColor = UIColor.Clear;
+                        currentTabBarItem.SetBadgeTextAttributes(
+                            new UIStringAttributes
+                            {
+                                ForegroundColor = bg.ToUIColor()
+                            }, UIControlState.Normal);
                     }
                     else
                     {
-                        TabBar.Items[index].BadgeValue = text;
-                        TabBar.Items[index].BadgeColor = bg.ToUIColor();
+                        currentTabBarItem.BadgeValue = text;
+                        currentTabBarItem.BadgeColor = bg.ToUIColor();
+                        currentTabBarItem.SetBadgeTextAttributes(
+                            new UIStringAttributes
+                            {
+                                ForegroundColor = textColor.ToUIColor()
+                            }, UIControlState.Normal);
                     }
-
-                    TabBar.Items[index].SetBadgeTextAttributes(
-                        new UIStringAttributes
-                        {
-                            ForegroundColor = textColor.ToUIColor()
-                        }, UIControlState.Normal);
-                }
-                else
-                {
-                    TabBar.Items[index].BadgeValue = default;
-                    TabBar.Items[index].BadgeColor = UIColor.Clear;
                 }
             }
         }

--- a/src/Xam.Shell.Badge.iOS/Renderers/BadgeShellItemRenderer.cs
+++ b/src/Xam.Shell.Badge.iOS/Renderers/BadgeShellItemRenderer.cs
@@ -77,6 +77,9 @@ namespace Xam.Shell.Badge.iOS.Renderers
         {
             if (TabBar.Items.Any())
             {
+                if (default == TabBar.Items.ElementAtOrDefault(index))
+                    return;
+
                 int.TryParse(text, out var badgeValue);
 
                 if (!string.IsNullOrEmpty(text))
@@ -92,8 +95,8 @@ namespace Xam.Shell.Badge.iOS.Renderers
                         TabBar.Items[index].BadgeColor = bg.ToUIColor();
                     }
 
-                    TabBar.Items[index]
-                        .SetBadgeTextAttributes(new UIStringAttributes()
+                    TabBar.Items[index].SetBadgeTextAttributes(
+                        new UIStringAttributes
                         {
                             ForegroundColor = textColor.ToUIColor()
                         }, UIControlState.Normal);


### PR DESCRIPTION
## PR overview
This PR includes:
- **An important change** where the color of the zero badge value is being picked from the background source (similar to android) instead of the text color value.
- Fixed iOS Shell item issue when IsVisible property of a ShellContent object is set to false (#25, latest comment);
- Some minor styling changes.

## What's changed
- iOS platform's shell item renderer;
- iOS sample project AppDelegate & Main files.

## Actions required
- Nuget package needs to be updated;
- Sample project needs to be updated.