### PR TITLE
Fixing recent issues #34, #35, #36;

### DIFF
--- a/src/Xam.Shell.Badge.Android/Renderers/BadgeShellItemRenderer.cs
+++ b/src/Xam.Shell.Badge.Android/Renderers/BadgeShellItemRenderer.cs
@@ -56,12 +56,22 @@ namespace Xam.Shell.Badge.Droid.Renderers
         /// <summary>
         /// <inheritdoc/>
         /// </summary>
+        public override void OnDestroyView()
+        {
+            base.OnDestroyView();
+
+            _bottomNavigationView = default;
+        }
+
+        /// <summary>
+        /// <inheritdoc/>
+        /// </summary>
         public override void OnResume()
         {
             base.OnResume();
 
             Device
-                .InvokeOnMainThreadAsync(InitBadges)
+                .InvokeOnMainThreadAsync(() => _shellContext.CurrentDrawerLayout.Post(InitBadges))
                 .SafeFireAndForget();
         }
 


### PR DESCRIPTION
## PR overview
This PR includes:
- Fix for Android `ObjectDisposedException: Cannot access a disposed object on BottomNavigationView` (issue #34 and issue #36);
- Fix for Android badge display when Shell's TabBarBackgroundColor="White" (issue #35).

## What's changed
- Android platform's shell item renderer.

## Actions required
- Nuget package needs to be updated;
- Sample project needs to be updated.